### PR TITLE
fix: remove CR for unix LF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "nextbasic" extension will be documented in this file.
 
+## [1.5.8] - 2020-09-25
+
+- Fix Windows carriage return and remove them during file formatting or export.
+
 ## [1.5.7] - 2020-09-25
 
 - txt2bas@1.14.9: ensure `#define` statements keep the proper tokenised values, important around using a define on a numeric then later casting as an int: https://github.com/remy/txt2bas/issues/26

--- a/lib/export-basic.command.js
+++ b/lib/export-basic.command.js
@@ -13,6 +13,7 @@ function exportCode({ bank = false, format = '3dos' } = {}) {
 
     const program = document
       .getText()
+      .replace(/\r/g, '')
       .split('\n')
       .filter((_) => _.startsWith('#program'))[0];
 

--- a/lib/formatter.provider.js
+++ b/lib/formatter.provider.js
@@ -12,12 +12,15 @@ const provider = {
 
       await textEditor.edit((editor) => {
         try {
-          text.split('\n').forEach((line, i) => {
-            const text = formatText(line, true);
-            const start = new vscode.Position(i, 0);
-            const end = new vscode.Position(i, line.length);
-            editor.replace(new vscode.Range(start, end), text);
-          });
+          text
+            .replace(/\r/g, '')
+            .split('\n')
+            .forEach((line, i) => {
+              const text = formatText(line, true);
+              const start = new vscode.Position(i, 0);
+              const end = new vscode.Position(i, line.length);
+              editor.replace(new vscode.Range(start, end), text);
+            });
         } catch (e) {}
       });
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "NextBASIC",
   "description": "NextBASIC",
   "publisher": "remysharp",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "prettier": {
     "singleQuote": true
   },
@@ -75,7 +75,8 @@
     },
     "configurationDefaults": {
       "[nextbasic]": {
-        "editor.formatOnType": true
+        "editor.formatOnType": true,
+        "files.eol": "\n"
       }
     },
     "languages": [


### PR DESCRIPTION
Fixes #29 

This change adds default `files.eof` contribution point (so Windows defaults to LF only) but also removes CR during the format and export process.